### PR TITLE
feat: update checksum for saxion-eduroam.py and improve connection handling

### DIFF
--- a/content/docs/networking/eduroam-network-installation.md
+++ b/content/docs/networking/eduroam-network-installation.md
@@ -59,13 +59,13 @@ A Python script automates the full `nmcli` connection setup for Saxion:
 curl -LO https://zephyrus-linux.stensel.nl/scripts/saxion-eduroam.py
 
 # 2. Verify checksum
-echo "f16ee75885b02fc773d96b28d7749ec48ee7e330814ccf58189c5da44db7eece  saxion-eduroam.py" | sha256sum -c
+echo "bef16a8ce91644a26cdd428f8dd0300de8e49ed72d9cbf4b6d39efea6d8facc1  saxion-eduroam.py" | sha256sum -c
 
 # 3. Run
 python3 saxion-eduroam.py
 ```
 
-**SHA256:** `f16ee75885b02fc773d96b28d7749ec48ee7e330814ccf58189c5da44db7eece`
+**SHA256:** `bef16a8ce91644a26cdd428f8dd0300de8e49ed72d9cbf4b6d39efea6d8facc1`
 
 The script removes any existing eduroam profile, prompts for your **username** via a GUI dialog (zenity, kdialog, or yad) or terminal fallback, and activates the connection. Your password is never asked by the script; it is requested by your GNOME Keyring at connection time and stored securely, never in plaintext.
 

--- a/content/docs/networking/eduroam-network-installation.nl.md
+++ b/content/docs/networking/eduroam-network-installation.nl.md
@@ -59,13 +59,13 @@ Een Python-script automatiseert de volledige `nmcli`-verbindingsconfiguratie voo
 curl -LO https://zephyrus-linux.stensel.nl/scripts/saxion-eduroam.py
 
 # 2. Controleer de checksum
-echo "f16ee75885b02fc773d96b28d7749ec48ee7e330814ccf58189c5da44db7eece  saxion-eduroam.py" | sha256sum -c
+echo "bef16a8ce91644a26cdd428f8dd0300de8e49ed72d9cbf4b6d39efea6d8facc1  saxion-eduroam.py" | sha256sum -c
 
 # 3. Uitvoeren
 python3 saxion-eduroam.py
 ```
 
-**SHA256:** `f16ee75885b02fc773d96b28d7749ec48ee7e330814ccf58189c5da44db7eece`
+**SHA256:** `bef16a8ce91644a26cdd428f8dd0300de8e49ed72d9cbf4b6d39efea6d8facc1`
 
 Het script verwijdert een eventueel bestaand eduroam-profiel, vraagt je **gebruikersnaam** via een GUI-dialoog (zenity, kdialog of yad) of terminal-fallback, en activeert de verbinding. Je wachtwoord wordt nooit door het script gevraagd; dat wordt bij het verbinden opgevraagd door je GNOME Keyring en veilig opgeslagen, nooit in platte tekst.
 

--- a/static/scripts/saxion-eduroam.py
+++ b/static/scripts/saxion-eduroam.py
@@ -251,20 +251,45 @@ class Installer:
             "If you do not see a password prompt, open your network settings and connect to eduroam manually."
         )
 
-        # Attempt to activate the connection and show only relevant output
+        # Attempt to activate the connection (best-effort; profile is already saved).
         res = subprocess.run(
             ["nmcli", "connection", "up", CON_NAME],
             capture_output=True,
             text=True
         )
+        output = res.stderr.strip() or res.stdout.strip()
+
         if res.returncode == 0:
+            print("[INFO] Connected to eduroam successfully.")
+        elif "network could not be found" in output or "No network with SSID" in output:
+            # Not in range; the passwd-file warning is also present but not the root cause.
             print(
-                "[INFO] Connection attempt started. If you entered your "
-                "password, you should be connected to eduroam."
+                "[INFO] eduroam profile saved, but the network could not be reached right now.\n"
+                "       You are probably not in range of an eduroam access point.\n"
+                "       The profile is stored — connect to eduroam from your network settings when nearby."
+            )
+        elif (
+            "Secrets were required" in output
+            or "Authentication rejected" in output
+        ):
+            print(
+                "[ERROR] eduroam profile saved, but authentication failed.\n"
+                "        Your credentials may be incorrect.\n"
+                "        Re-run the script with the correct username, or update the profile in\n"
+                "        your network settings (nmcli connection edit eduroam)."
+            )
+        elif "passwd-file" in output or "cannot ask without" in output:
+            # nmcli was not invoked with --ask; keyring will prompt on first connect.
+            print(
+                "[INFO] eduroam profile saved. "
+                "Enter your password when prompted by your desktop keyring upon connecting."
             )
         else:
-            print("[ERROR] Could not activate eduroam connection:")
-            print(res.stderr.strip() or res.stdout.strip())
+            print(
+                "[WARN] eduroam profile saved, but automatic activation failed.\n"
+                "       You can connect manually via your network settings.\n"
+                f"       nmcli: {output}"
+            )
 
 
 def main():


### PR DESCRIPTION
## Summary

This PR improves the error handling in the eduroam connection script for Linux. It now tells when the user is not in range of a nearby AP, or if the auth failed. This will give the end-user more context on where to look for.

## Type of change

<!-- Check all that apply -->

- [x] `feat` — new page or feature

> [PR title and commit types must follow these standards — view the contributing guide](https://github.com/Stensel8/Zephyrus-Linux/blob/main/CONTRIBUTING.md#commit-messages)

## Checklist

- [x] PR title follows the commit convention (e.g. `fix: correct nmcli command in eduroam guide`)
- [x] Both EN and NL versions updated (if applicable)
- [x] Media is in AVIF format (not PNG/JPG)
- [x] No broken image references (`/images/*.avif` all exist in `static/images/`)
- [x] Tested locally with `hugo server`
